### PR TITLE
Fix Memory and File Descriptor Leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ the default handler, this is outside the domain of `update-alternatives`.
 Another major drawback of `update-alternatives` is that it is a state
 system and this state is modified or updated at *installation* time. If
 the state of the running system is to be kept separate from the installation
-state (eg. multiple snapshots of parts of the system), the symlinks
+state (eg. multiple snapshots of parts of the system), the symlinks'
 state can become stale or simply wrong without a *possibility* of a
 fallback mechanism.
 
@@ -37,14 +37,14 @@ user configuration files. By default, the preferred alternative with the
 highest priority is executed. If an alternative is selected by the user
 or the system administrator, this alternative will be executed instead.
 If the user or system selection is unavailable, the system will fall
-back to the default, highest installed priority alternative.
+back to the default, highest priority, installed alternative.
 
 `alts` is a simple wrapper around two config files. First is a
 config file provided by packages that describe the alternatives
 provided. The second config file is either a system or a user
 preferences file that overrides default alternative preference.
 
-Packages need to ship their package preferences in following format,
+Packages need to ship their package preferences in the following format,
 
 	/usr/share/libalternatives/<binary>/<pref>.conf
 
@@ -59,14 +59,14 @@ The config file must be of the following format:
 	man=<list of manpages>
 	group=<list of binaries>
 
-where *binary* entry is mandatory.
+where the *binary* entry is mandatory.
 
 Typically, the *binary* can then be a symlink to
 */usr/bin/alts* that will **exec()** the configured binary
 with largest pref number forwarding all the arguments to the configured
 binary.
 
-*list* constitutes a comma (,) separated items
+*list* consists of comma (,) separated items
 
 For example:
 
@@ -93,6 +93,7 @@ the state of one of the executables with a `group` entry.
 
 Notes
 -----
+
 `libalternatives` is NOT aimed to be a replacement for
 `update-alternatives`. It is meant as an alternative that tends to stay
 out of the way and provides more flexibility and stability for users and

--- a/doc/alts.1
+++ b/doc/alts.1
@@ -18,9 +18,9 @@ alts [options]
 
 .SH DESCRIPTION
 
-alts is a defaul program manager and its aim is to provide an alternative to update-alternatives system
-without relying on symlinks. Instead of symlinks, it relies on configuration files. This allows for
-simple per-system or per-user override of default configuration.
+alts is a default program manager and its aim is to provide an alternative to the update-alternatives
+system without relying on symlinks. Instead of symlinks, it relies on configuration files. This allows
+for a simple per-system or per-user override of the default configuration.
 
 .SH OPTIONS
 
@@ -30,7 +30,7 @@ simple per-system or per-user override of default configuration.
        sets an override with a given priority as default
        if priority is not set, then resets to default by removing override
        -u -- user override, default for non-root users
-       -s -- system overrude, default for root users
+       -s -- system override, default for root users
        -n -- program to override with a given priority alternative
 
 

--- a/src/libalternatives.c
+++ b/src/libalternatives.c
@@ -691,6 +691,8 @@ int libalts_exec_default(char *argv[])
 
 	if (IS_DEBUG)
 		fprintf(stderr, "execDefault() failed with target %s\n", (alts ? alts->target : NULL));
+	if (alts)
+		libalts_free_alternatives_ptr(&alts);
 	errno = ENOENT;
 	return -1;
 }

--- a/src/libalternatives.c
+++ b/src/libalternatives.c
@@ -554,10 +554,11 @@ int libalts_write_binary_configured_priority_to_file(const char *binary_name, in
 	else
 		new_data = setBinaryPriorityAndReturnUpdatedConfig(priority, state);
 
-	if (new_data == NULL)
-		return -1;
+	int ret = -1;
 
-	int ret = saveConfigData(config_path, new_data);
+	if (new_data != NULL)
+		ret = saveConfigData(config_path, new_data);
+
 	doneConfigParser(state);
 	return ret;
 }

--- a/src/libalternatives.c
+++ b/src/libalternatives.c
@@ -520,9 +520,12 @@ static int saveConfigData(const char *config_path, const char *data)
 	}
 
 	if (close(fd) == -1 && errno != EINTR) {
+		fd = -1;
 		ret = -1;
 		goto ret;
 	}
+
+	fd = -1;
 
 	ret = rename(saved_path, config_path);
 
@@ -530,6 +533,8 @@ ret:
 	olderr = errno;
 	free((void*)saved_path);
 	errno = olderr;
+	if (fd != -1)
+		close(fd);
 	return ret;
 }
 

--- a/src/libalternatives.c
+++ b/src/libalternatives.c
@@ -115,11 +115,11 @@ static int PriorityMatch_getExact(int a, __attribute__((unused)) int b, void *pr
 
 static int findAltConfig(const char *binary_name, PriorityMatchFunction priority_match_func, int *prio, void *data)
 {
-	int configdirfd = open(getConfigDirectory(), O_DIRECTORY, O_RDONLY);
+	int configdirfd = open(getConfigDirectory(), O_DIRECTORY, O_RDONLY | O_CLOEXEC);
 	if (configdirfd < 0)
 		return -1;
 
-	int binaryconfigdirfd = openat(configdirfd, binary_name, O_DIRECTORY, O_RDONLY);
+	int binaryconfigdirfd = openat(configdirfd, binary_name, O_DIRECTORY, O_RDONLY | O_CLOEXEC);
 	if (binaryconfigdirfd < 0) {
 		int saved_error = errno;
 		close(configdirfd);
@@ -188,7 +188,7 @@ static int findAltConfig(const char *binary_name, PriorityMatchFunction priority
 		return -1;
 	}
 
-	int fd = openat(binaryconfigdirfd, filename, 0, O_RDONLY);
+	int fd = openat(binaryconfigdirfd, filename, 0, O_RDONLY | O_CLOEXEC);
 	if (fd < 0) {
 		int saved_error = errno;
 		free((void*)filename);
@@ -283,7 +283,7 @@ int libalts_load_available_binaries(char ***binaries_ptr, size_t *size)
 {
 	errno = 0;
 
-	int fd = open(getConfigDirectory(), O_RDONLY | O_DIRECTORY);
+	int fd = open(getConfigDirectory(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
 	if (fd == -1)
 		return -1;
 
@@ -378,7 +378,7 @@ int libalts_load_binary_priorities(const char *binary_name, int **alts, size_t *
 
 static ssize_t loadConfigData(const char *config_path, char *data, const ssize_t max_config_size)
 {
-	int fd = open(config_path, O_RDONLY | O_NOFOLLOW);
+	int fd = open(config_path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
 	if (fd < 0)
 		return -1;
 
@@ -449,7 +449,7 @@ static int saveConfigData(const char *config_path, const char *data)
 	if (stat(config_path, &st) == 0) {
 		mode = st.st_mode & (S_IRWXO | S_IRWXG | S_IRWXU);
 	}
-	int fd = open(saved_path, O_CREAT | O_TRUNC | O_WRONLY, mode);
+	int fd = open(saved_path, O_CREAT | O_TRUNC | O_WRONLY | O_CLOEXEC, mode);
 	if (fd < 0) {
 		ret = -1;
 		goto ret;

--- a/utils/group_consistency_rules.c
+++ b/utils/group_consistency_rules.c
@@ -77,6 +77,7 @@ static void appendError(const struct AlternativeLink *data, const char *message,
 
 int checkGroupConsistencies(const struct InstalledBinaryData *data, unsigned n_binaries, enum ConsistencyCheckFlags flags, struct ConsistencyError **errors, unsigned *n_errors)
 {
+	(void)flags;
 	int ret = 0;
 
 	if (n_errors != NULL)

--- a/utils/list_binaries.c
+++ b/utils/list_binaries.c
@@ -57,11 +57,12 @@ static void filterStringsArray(const char *filter, char **bins, size_t *bin_size
 
 static int loadInstalledBinariesAndTheirOverrides(const char *program_filter, struct InstalledBinaryData **binaries_ptr, size_t *bin_size)
 {
-	char **binary_names_array;
+	char **binary_names_array = NULL;
+	int ret = -1;
 
 	if (libalts_load_available_binaries(&binary_names_array, bin_size) != 0) {
 		perror(binname);
-		return -1;
+		goto err;
 	}
 
 	filterStringsArray(program_filter, binary_names_array, bin_size);
@@ -80,7 +81,7 @@ static int loadInstalledBinariesAndTheirOverrides(const char *program_filter, st
 			}
 			else {
 				perror(binname);
-				return -1;
+				goto err;
 			}
 		}
 
@@ -108,9 +109,13 @@ static int loadInstalledBinariesAndTheirOverrides(const char *program_filter, st
 			binary->alts[i] = alts;
 		}
 	}
+
+	ret = 0;
+
+err:
 	free(binary_names_array);
 
-	return 0;
+	return ret;
 }
 
 static void printErrorsAssociatedWithBinary(const struct AlternativeLink *link, const struct ConsistencyError *errors, unsigned n_errors)


### PR DESCRIPTION
Results from security review bsc#1191692. Apart from some cosmetical stuff this mainly addresses memory and file descriptors leaks in the code. One file descriptor leak in `loadConfigData()` (see commit f2c12a766d48d247283a6119ee014161f74ffeaf) even affects the success code path and a user's config file descriptor will be inherited to the child process(es).

I suggest carefuly review of the changes, since the error handling situations are tricky to get right even with the gotos I introduced.