### PR TITLE
Argv0 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,26 @@ binary.
 Argv[0]
 -------
 
-In normal cases, argv[0] contains name of the executed target
-by the *alts* binary. In the example below, this would be *vim*. If the
-called process needs the name of for argv[0], set the option 
-*options=KeepArgv0* in the config file.
+In normal cases, argv[0] retaines the path of original binary or symlink
+to the *alts* binary. When UpdateArgv0 is specified, the argv[0] will be
+set to the binary executed by *alts*, so this would be *vim*.
 
-Note: Only these two options for argv[0] are available. Some called processes expect other names which cannot be handled by libalternatives.
+Note: Only these two options for argv[0] are available. Some called processes expect
+other names which cannot be handled by libalternatives without helper binaries.
 
 For example:
 
 	binary=/usr/bin/vim
 	man=vim.1
-	options=KeepArgv0
+	options=UpdateArgv0
 
 *alts* is also the configuration utility that allows system or user
 override of the default binary. See *alts(1)* for details.
+
+**Change Of Behaviour**: Previously, argv0 would be set to basename of the
+binary being executed. To be better compatible with symlinks, this behaviour
+required UpdateArv0 Option to be specified. Without that option, KeepArgv0
+is assumed by default.
 
 Groups
 ------

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Argv[0]
 
 In normal cases, argv[0] retaines the path of original binary or symlink
 to the *alts* binary. When UpdateArgv0 is specified, the argv[0] will be
-set to the binary executed by *alts*, so this would be *vim*.
+set to the absolute path of binary executed by *alts*, so this would be
+*/usr/bin/vim*.
 
 Note: Only these two options for argv[0] are available. Some called processes expect
 other names which cannot be handled by libalternatives without helper binaries.

--- a/src/libalternatives.c
+++ b/src/libalternatives.c
@@ -671,7 +671,7 @@ int libalts_exec_default(char *argv[])
 {
 	struct AlternativeLink *alts, *orig_alts;
 	checkEnvDebug();
-	loadAlternatives(argv[0], &alts);
+	loadAlternatives(basename(argv[0]), &alts);
 
 	orig_alts = alts;
 	if (alts) {

--- a/src/libalternatives.c
+++ b/src/libalternatives.c
@@ -669,10 +669,11 @@ static int loadAlternatives(const char *binary_name, struct AlternativeLink **al
 PUBLIC_FUNC
 int libalts_exec_default(char *argv[])
 {
-	struct AlternativeLink *alts;
+	struct AlternativeLink *alts, *orig_alts;
 	checkEnvDebug();
 	loadAlternatives(argv[0], &alts);
 
+	orig_alts = alts;
 	if (alts) {
 		while (alts->type != ALTLINK_EOL) {
 			if (alts->type == ALTLINK_BINARY) {
@@ -688,8 +689,8 @@ int libalts_exec_default(char *argv[])
 
 	if (IS_DEBUG)
 		fprintf(stderr, "execDefault() failed with target %s\n", (alts ? alts->target : NULL));
-	if (alts)
-		libalts_free_alternatives_ptr(&alts);
+	if (orig_alts)
+		libalts_free_alternatives_ptr(&orig_alts);
 	errno = ENOENT;
 	return -1;
 }

--- a/src/libalternatives.c
+++ b/src/libalternatives.c
@@ -689,9 +689,16 @@ int libalts_exec_default(char *argv[])
 
 	if (IS_DEBUG)
 		fprintf(stderr, "execDefault() failed with target %s\n", (alts ? alts->target : NULL));
+
+	int saved_errno = errno;
 	if (orig_alts)
 		libalts_free_alternatives_ptr(&orig_alts);
-	errno = ENOENT;
+
+	if (saved_errno != 0)
+		errno = saved_errno;
+	else
+		errno = ENOENT;
+
 	return -1;
 }
 

--- a/src/libalternatives.c
+++ b/src/libalternatives.c
@@ -669,8 +669,6 @@ static int loadAlternatives(const char *binary_name, struct AlternativeLink **al
 PUBLIC_FUNC
 int libalts_exec_default(char *argv[])
 {
-	argv[0]=basename(argv[0]);
-
 	struct AlternativeLink *alts;
 	checkEnvDebug();
 	loadAlternatives(argv[0], &alts);
@@ -678,7 +676,7 @@ int libalts_exec_default(char *argv[])
 	if (alts) {
 		while (alts->type != ALTLINK_EOL) {
 			if (alts->type == ALTLINK_BINARY) {
-				if ((alts->options & ALTLINK_OPTIONS_KEEPARGV0) == 0)
+				if ((alts->options & ALTLINK_OPTIONS_UPDATEARGV0) != 0)
 					argv[0] = (char*)alts->target;
 				execv(alts->target, argv);
 				perror("Failed to execute target.");

--- a/src/libalternatives.h
+++ b/src/libalternatives.h
@@ -34,6 +34,7 @@ enum AlternativeLinkOptions
 {
 	ALTLINK_OPTIONS_NONE = 0,
 	ALTLINK_OPTIONS_KEEPARGV0 = 1,
+	ALTLINK_OPTIONS_UPDATEARGV0 = 2,
 };
 
 struct AlternativeLink

--- a/src/options_parser.c
+++ b/src/options_parser.c
@@ -251,6 +251,35 @@ static int parser_asssertOption_KeepArgv0(const char *data, size_t len, struct O
 	return state->parser_func(data, len, state);
 }
 
+static int parser_asssertOption_UpdateArgv0(const char *data, size_t len, struct OptionsParserState *state)
+{
+	if (len == 0)
+		return 0;
+
+	const char token[] = "UpdateArgv0";
+	u_int32_t pos = state->parser_func_param;
+	u_int32_t max_pos_to_match = MIN(sizeof(token)-1, pos+len);
+
+	while (pos < max_pos_to_match && *data == token[pos]) {
+		pos++;
+		data++;
+		len--;
+	}
+
+	if (pos == max_pos_to_match) {
+		if (pos == sizeof(token)-1) {
+			state->parser_func = parser_skipWhitespaceBeforeCommaAndOption;
+			state->options |= ALTLINK_OPTIONS_UPDATEARGV0;
+		}
+		else
+			state->parser_func_param = pos;
+	}
+	else
+		state->parser_func = parser_alreadyErrorNoResumePossible;
+
+	return state->parser_func(data, len, state);
+}
+
 static int parser_parseOptions(const char *data, size_t len, struct OptionsParserState *state)
 {
 	if (len == 0)
@@ -259,6 +288,10 @@ static int parser_parseOptions(const char *data, size_t len, struct OptionsParse
 	switch (*data) {
 		case 'K':
 			state->parser_func = parser_asssertOption_KeepArgv0;
+			state->parser_func_param = 1;
+			break;
+		case 'U':
+			state->parser_func = parser_asssertOption_UpdateArgv0;
 			state->parser_func_param = 1;
 			break;
 		case '\n':

--- a/test/alternatives_tests.c
+++ b/test/alternatives_tests.c
@@ -527,6 +527,26 @@ static void validExecCommandReplacedArgv0()
 	}
 }
 
+static void validExecCommandUpdateArgv0()
+{
+	char *command_update_argv[] = { "/usr/path/area49", "argv_replaced_helper", NULL };
+	pid_t child_pid = fork();
+	int status = 1000;
+
+	switch (child_pid) {
+		case -1:
+			CU_ASSERT_FATAL(-1);
+			return;
+		case 0:
+			libalts_exec_default(command_update_argv);
+			exit(100);
+		default:
+			CU_ASSERT_EQUAL_FATAL(wait(&status), child_pid);
+			CU_ASSERT(WIFEXITED(status));
+			CU_ASSERT_EQUAL(WEXITSTATUS(status), 0);
+	}
+}
+
 void addAlternativesAppTests()
 {
 	CU_pSuite suite = CU_add_suite_with_setup_and_teardown("Alternative App Tests", setupTests, cleanupTests, storeErrorCount, printOutputOnErrorIncrease);
@@ -548,4 +568,5 @@ void addAlternativesAppTests()
 	CU_ADD_TEST(suite, validExecCommand);
 	CU_ADD_TEST(suite, validExecCommandKeepArgv0);
 	CU_ADD_TEST(suite, validExecCommandReplacedArgv0);
+	CU_ADD_TEST(suite, validExecCommandUpdateArgv0);
 }

--- a/test/options_parser_tests.c
+++ b/test/options_parser_tests.c
@@ -253,6 +253,17 @@ static void parseWithGoodOptions()
 	CU_ASSERT_EQUAL(result->options, ALTLINK_OPTIONS_KEEPARGV0);
 }
 
+static void parseWithUpdateArgv0Option()
+{
+	const char data[] = "binary=/usr/bin/ls\noptions=UpdateArgv0";
+
+	CU_ASSERT_PTR_NOT_NULL(state = initOptionsParser());
+	CU_ASSERT_EQUAL(parseOptionsData(data, sizeof(data)-1, state), 0);
+	CU_ASSERT_PTR_NOT_NULL(result = doneOptionsParser(10, state));
+
+	CU_ASSERT_EQUAL(result->options, ALTLINK_OPTIONS_UPDATEARGV0);
+}
+
 static void parseLongGroupsLine()
 {
 	const char data[] = "binary=testing\ngroup=vi,vim,ex,gex,edit,view,rview,eview,vimdiff,gvimdiff, 1  ,2,3,4,5,10";
@@ -305,5 +316,6 @@ void addOptionsParserTests()
 	CU_ADD_TEST(tests, parsesMultipleGroupsAsLatestGroupList);
 	CU_ADD_TEST(tests, parseWithBadOptions);
 	CU_ADD_TEST(tests, parseWithGoodOptions);
+	CU_ADD_TEST(tests, parseWithUpdateArgv0Option);
 	CU_ADD_TEST(tests, parseLongGroupsLine);
 }

--- a/test/test_exec/area48/10.conf
+++ b/test/test_exec/area48/10.conf
@@ -1,3 +1,3 @@
 man=test
 binary=./build/test/argv_replaced_helper
-options=
+options=UpdateArgv0


### PR DESCRIPTION
Keeping argv0 as called keeps behaviour of basically having a symlink to target binary. Replacing argv0 loses this information unnecessarily as it's used in some cases.

This is behaviour change of default mode of operation. `KeepArgv0` option is deprecated as it's default behaviour.
